### PR TITLE
Introduce basic join functionality as an experimental feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ TicketRepo.fetch(
     to:      = Skipped,
     date:    = Skipped
   ),
-  sortOpt = Some("name" -> Repo.Sort.Ascending),
+  sortOpt = Some("name" -> Sort.Ascending),
   limitOpt = Some(5)
 ).to[List]
 ```

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Create.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Create.scala
@@ -1,0 +1,20 @@
+package io.scalaland.ocdquery
+
+import cats.Id
+import io.scalaland.ocdquery.internal.SkipUnit
+
+object Create {
+
+  def value[ValueF[_[_]]](implicit skipUnit: SkipUnit[ValueF[Id]]): Builder[skipUnit.SU, ValueF[Id]] =
+    (tuple: skipUnit.SU) => skipUnit.from(tuple)
+
+  def entity[EntityF[_[_], _[_]]](
+    implicit skipUnit: SkipUnit[EntityF[Id, UnitF]]
+  ): Builder[skipUnit.SU, EntityF[Id, UnitF]] =
+    (tuple: skipUnit.SU) => skipUnit.from(tuple)
+
+  trait Builder[SU, C] {
+
+    def fromTuple(tuple: SU): C
+  }
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/DefaultColumnNames.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/DefaultColumnNames.scala
@@ -1,0 +1,31 @@
+package io.scalaland.ocdquery
+
+import shapeless._
+import shapeless.labelled.FieldType
+
+trait DefaultColumnNames[A] {
+
+  def get(): A
+}
+
+object DefaultColumnNames {
+
+  def forValue[ValueF[_[_]]](implicit default: DefaultColumnNames[ValueF[ColumnNameF]]): ValueF[ColumnNameF] =
+    default.get()
+
+  def forEntity[EntityF[_[_], _[_]]](
+    implicit default: DefaultColumnNames[EntityF[ColumnNameF, ColumnNameF]]
+  ): EntityF[ColumnNameF, ColumnNameF] = default.get()
+
+  implicit val hnilCase: DefaultColumnNames[HNil] = () => HNil
+
+  implicit def hconsCase[LH <: Symbol, T <: HList](
+    implicit label: Witness.Aux[LH],
+    tailDefault:    DefaultColumnNames[T]
+  ): DefaultColumnNames[FieldType[LH, ColumnName] :: T] =
+    () => labelled.field[LH][ColumnName](label.value.name) :: tailDefault.get()
+
+  implicit def productCase[P, Rep <: HList](implicit pGen: LabelledGeneric.Aux[P, Rep],
+                                            defaultRep:    DefaultColumnNames[Rep]): DefaultColumnNames[P] =
+    () => pGen.from(defaultRep.get())
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
@@ -25,7 +25,7 @@ class Fetcher[C, E: Read, S, N](val meta: NamedRepoMeta[C, E, S, N]) {
     val where  = fr"WHERE" ++ fromSelect(select).asAnd
     val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
     val limit  = limitOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
-    (fr"SELECT " ++ * ++ fr"FROM" ++ table ++ joinOn ++ where ++ orderBy ++ offset ++ limit).query[Entity]
+    (fr"SELECT" ++ * ++ fr"FROM" ++ table ++ joinOn ++ where ++ orderBy ++ offset ++ limit).query[Entity]
   }
 
   def join[C1, E1, S1, N1, C0, E0, S0, N0](repo2: Repo[C1, E1, S1, N1], on: (N => ColumnName, N1 => ColumnName)*)(

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
@@ -13,18 +13,18 @@ class Fetcher[C, E: Read, S, N](val meta: NamedRepoMeta[C, E, S, N]) {
   val read: Read[E] = Read[E]
 
   def fetch(select:    Select,
-            sortOpt:   Option[(N => ColumnName, Repo.Sort)] = None,
+            sortOpt:   Option[(N => ColumnName, Sort)] = None,
             offsetOpt: Option[Long] = None,
             limitOpt:  Option[Long] = None): Query0[Entity] = {
     val orderBy = sortOpt match {
-      case Some((columnf, Repo.Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
-      case Some((columnf, Repo.Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
-      case None                                  => Fragment.empty
+      case Some((columnf, Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
+      case Some((columnf, Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
+      case None                             => Fragment.empty
     }
     val joinOn = joinedOn.map(fr"ON" ++ _).getOrElse(Fragment.empty)
     val where  = fr"WHERE" ++ fromSelect(select).asAnd
     val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
-    val limit  = limitOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
+    val limit  = limitOpt.map(limit => Fragment.const(s"LIMIT $limit")).getOrElse(Fragment.empty)
     (fr"SELECT" ++ * ++ fr"FROM" ++ table ++ joinOn ++ where ++ orderBy ++ offset ++ limit).query[Entity]
   }
 

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Fetcher.scala
@@ -1,0 +1,41 @@
+package io.scalaland.ocdquery
+
+import cats.Id
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import io.scalaland.ocdquery.internal.{ RandomName, TupleAppender }
+
+class Fetcher[C, E: Read, S, N](val meta: NamedRepoMeta[C, E, S, N]) {
+
+  import meta._
+
+  val read: Read[E] = Read[E]
+
+  def fetch(select:    Select,
+            sortOpt:   Option[(N => ColumnName, Repo.Sort)] = None,
+            offsetOpt: Option[Long] = None,
+            limitOpt:  Option[Long] = None): Query0[Entity] = {
+    val orderBy = sortOpt match {
+      case Some((columnf, Repo.Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
+      case Some((columnf, Repo.Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
+      case None                                  => Fragment.empty
+    }
+    val joinOn = joinedOn.map(fr"ON" ++ _).getOrElse(Fragment.empty)
+    val where  = fr"WHERE" ++ fromSelect(select).asAnd
+    val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
+    val limit  = limitOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
+    (fr"SELECT " ++ * ++ fr"FROM" ++ table ++ joinOn ++ where ++ orderBy ++ offset ++ limit).query[Entity]
+  }
+
+  def join[C1, E1, S1, N1, C0, E0, S0, N0](repo2: Repo[C1, E1, S1, N1], on: (N => ColumnName, N1 => ColumnName)*)(
+    implicit
+    cta: TupleAppender[C, C1, C0],
+    eta: TupleAppender[E, E1, E0],
+    sta: TupleAppender[S, S1, S0],
+    nta: TupleAppender[N, N1, N0]
+  ): Fetcher[C0, E0, S0, N0] = {
+    implicit val readE0: Read[E0] = (read, repo2.read).mapN((e, e1) => eta.append(e, e1))
+    new Fetcher(meta.join(repo2.meta.as(RandomName.next), on.toSeq: _*))
+  }
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
@@ -4,9 +4,9 @@ import cats.Id
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import io.scalaland.ocdquery.internal.RandomName
+import io.scalaland.ocdquery.internal.{ Empty, RandomName }
 
-class Repo[C, E: Read, S, N](val meta: UnnamedRepoMeta[C, E, S, N]) { repo =>
+class Repo[C, E: Read, S: Empty, N](val meta: UnnamedRepoMeta[C, E, S, N]) { repo =>
 
   import meta._
 
@@ -46,11 +46,13 @@ class Repo[C, E: Read, S, N](val meta: UnnamedRepoMeta[C, E, S, N]) { repo =>
     implicit val readEE1: Read[(E, E1)] = (read, repo2.read).mapN((e, e1) => e -> e1)
     new Fetcher(repo.meta.as(RandomName.next).join(repo2.meta.as(RandomName.next), on.toSeq: _*))
   }
+
+  lazy val emptySelect: Select = Empty[Select].value
 }
 
 object Repo {
 
-  def apply[C, E: Read, S, N](meta: UnnamedRepoMeta[C, E, S, N]): Repo[C, E, S, N] = new Repo(meta)
+  def apply[C, E: Read, S: Empty, N](meta: UnnamedRepoMeta[C, E, S, N]): Repo[C, E, S, N] = new Repo(meta)
 
   sealed trait Sort extends Product with Serializable
   object Sort {

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
@@ -25,16 +25,16 @@ class Repo[C, E: Read, S: Empty, N](val meta: UnnamedRepoMeta[C, E, S, N]) { rep
   }
 
   def fetch(select:    Select,
-            sortOpt:   Option[(N => ColumnName, Repo.Sort)] = None,
+            sortOpt:   Option[(N => ColumnName, Sort)] = None,
             offsetOpt: Option[Long] = None,
             limitOpt:  Option[Long] = None): Query0[Entity] = {
     val orderBy = sortOpt match {
-      case Some((columnf, Repo.Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
-      case Some((columnf, Repo.Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
-      case None                                  => Fragment.empty
+      case Some((columnf, Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
+      case Some((columnf, Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
+      case None                             => Fragment.empty
     }
     val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
-    val limit  = limitOpt.map(offset => Fragment.const(s"LIMIT $offset")).getOrElse(Fragment.empty)
+    val limit  = limitOpt.map(limit => Fragment.const(s"LIMIT $limit")).getOrElse(Fragment.empty)
 
     (fr"SELECT" ++ * ++ fr"FROM" ++ table ++ fr"WHERE" ++ fromSelect(select).asAnd ++ orderBy ++ offset ++ limit)
       .query[Entity]
@@ -86,10 +86,4 @@ object Repo {
     emptySelect:   Empty[EntityF[Selectable, Selectable]],
   ): Repo[EntityF[Id, UnitF], EntityF[Id, Id], EntityF[Selectable, Selectable], EntityF[ColumnNameF, ColumnNameF]] =
     apply(RepoMeta.forEntity[EntityF](tableName, columns))
-
-  sealed trait Sort extends Product with Serializable
-  object Sort {
-    case object Ascending extends Sort
-    case object Descending extends Sort
-  }
 }

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
@@ -3,9 +3,11 @@ package io.scalaland.ocdquery
 import doobie._
 import doobie.implicits._
 
-class Repo[C, E: Read, S](val meta: RepoMeta[C, E, S]) {
+class Repo[C, E: Read, S, N](val meta: RepoMeta[C, E, S, N]) {
 
   import meta._
+
+  // TODO: add handling for joins
 
   def insert(create: Create): Update0 = {
     val fragments = fromCreate(create)
@@ -35,6 +37,8 @@ class Repo[C, E: Read, S](val meta: RepoMeta[C, E, S]) {
 }
 
 object Repo {
+
+  def apply[C, E: Read, S, N](meta: RepoMeta[C, E, S, N]): Repo[C, E, S, N] = new Repo(meta)
 
   sealed trait Sort extends Product with Serializable
   object Sort {

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
@@ -28,7 +28,8 @@ class Repo[C, E: Read, S, N](val meta: UnnamedRepoMeta[C, E, S, N]) { repo =>
     }
     val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
     val limit  = limitOpt.map(offset => Fragment.const(s"LIMIT $offset")).getOrElse(Fragment.empty)
-    (fr"SELECT " ++ * ++ fr"FROM" ++ table ++ fr"WHERE" ++ fromSelect(select).asAnd ++ orderBy ++ offset ++ limit)
+
+    (fr"SELECT" ++ * ++ fr"FROM" ++ table ++ fr"WHERE" ++ fromSelect(select).asAnd ++ orderBy ++ offset ++ limit)
       .query[Entity]
   }
 

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Repo.scala
@@ -1,13 +1,16 @@
 package io.scalaland.ocdquery
 
+import cats.Id
+import cats.implicits._
 import doobie._
 import doobie.implicits._
+import io.scalaland.ocdquery.internal.RandomName
 
-class Repo[C, E: Read, S, N](val meta: RepoMeta[C, E, S, N]) {
+class Repo[C, E: Read, S, N](val meta: UnnamedRepoMeta[C, E, S, N]) { repo =>
 
   import meta._
 
-  // TODO: add handling for joins
+  val read: Read[E] = Read[E]
 
   def insert(create: Create): Update0 = {
     val fragments = fromCreate(create)
@@ -15,13 +18,13 @@ class Repo[C, E: Read, S, N](val meta: RepoMeta[C, E, S, N]) {
   }
 
   def fetch(select:    Select,
-            sortOpt:   Option[(ColumnName, Repo.Sort)] = None,
+            sortOpt:   Option[(N => ColumnName, Repo.Sort)] = None,
             offsetOpt: Option[Long] = None,
             limitOpt:  Option[Long] = None): Query0[Entity] = {
     val orderBy = sortOpt match {
-      case Some((column, Repo.Sort.Ascending))  => Fragment.const(s"ORDER BY $column ASC")
-      case Some((column, Repo.Sort.Descending)) => Fragment.const(s"ORDER BY $column DESC")
-      case None                                 => Fragment.empty
+      case Some((columnf, Repo.Sort.Ascending))  => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} ASC")
+      case Some((columnf, Repo.Sort.Descending)) => Fragment.const(s"ORDER BY ${forNames[Id](columnf)} DESC")
+      case None                                  => Fragment.empty
     }
     val offset = offsetOpt.map(offset => Fragment.const(s"OFFSET $offset")).getOrElse(Fragment.empty)
     val limit  = limitOpt.map(offset => Fragment.const(s"LIMIT $offset")).getOrElse(Fragment.empty)
@@ -34,11 +37,19 @@ class Repo[C, E: Read, S, N](val meta: RepoMeta[C, E, S, N]) {
 
   def delete(select: Select): Update0 =
     (fr"DELETE FROM" ++ table ++ fr"WHERE" ++ fromSelect(select).asAnd).update
+
+  def col(f: Names => ColumnName): Names => ColumnName = f
+
+  def join[C1, E1, S1, N1](repo2: Repo[C1, E1, S1, N1],
+                           on:    (N => ColumnName, N1 => ColumnName)*): Fetcher[(C, C1), (E, E1), (S, S1), (N, N1)] = {
+    implicit val readEE1: Read[(E, E1)] = (read, repo2.read).mapN((e, e1) => e -> e1)
+    new Fetcher(repo.meta.as(RandomName.next).join(repo2.meta.as(RandomName.next), on.toSeq: _*))
+  }
 }
 
 object Repo {
 
-  def apply[C, E: Read, S, N](meta: RepoMeta[C, E, S, N]): Repo[C, E, S, N] = new Repo(meta)
+  def apply[C, E: Read, S, N](meta: UnnamedRepoMeta[C, E, S, N]): Repo[C, E, S, N] = new Repo(meta)
 
   sealed trait Sort extends Product with Serializable
   object Sort {

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
@@ -40,43 +40,47 @@ sealed trait UnnamedRepoMeta[C, E, S, N] extends RepoMeta[C, E, S, N] { repo =>
       val fromSelect: Select => ListMap[ColumnName, Fragment] =
         s => repo.fromSelect(s).map { case (k, v) => (name + "." + k) -> v }
 
-      def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = repo.forNames(f).map("." + _)
+      def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = repo.forNames(f).map(name + "." + _)
 
-      val joinOn: Option[Fragment] = None
+      val joinedOn: Option[Fragment] = None
     }
 }
 
 sealed trait NamedRepoMeta[C, E, S, N] extends RepoMeta[C, E, S, N] { repo1 =>
 
-  val joinOn: Option[Fragment]
+  val joinedOn: Option[Fragment]
 
-  def join[C1, E1, S1, N1](
+  def join[C1, E1, S1, N1, C0, E0, S0, N0](
     repo2: NamedRepoMeta[C1, E1, S1, N1],
     on:    (N => ColumnName, N1 => ColumnName)*
-  ): NamedRepoMeta[(C, C1), (E, E1), (S, S1), (N, N1)] =
-    new NamedRepoMeta[(C, C1), (E, E1), (S, S1), (N, N1)] {
+  )(implicit
+    cta: TupleAppender[C, C1, C0],
+    eta: TupleAppender[E, E1, E0],
+    sta: TupleAppender[S, S1, S0],
+    nta: TupleAppender[N, N1, N0]): NamedRepoMeta[C0, E0, S0, N0] =
+    new NamedRepoMeta[C0, E0, S0, N0] {
 
-      // TODO: for now only join
+      // TODO: for now only "join"
       val table:       Fragment            = repo1.table ++ Fragment.const(" JOIN ") ++ repo2.table
       val columnNames: ListSet[ColumnName] = repo1.columnNames ++ repo1.columnNames
 
-      val fromCreate: ((C, C1)) => ListMap[ColumnName, Fragment] = {
+      val fromCreate: C0 => ListMap[ColumnName, Fragment] = (cta.revert _) andThen {
         case (c, c1) => repo1.fromCreate(c) ++ repo2.fromCreate(c1)
       }
-      val fromEntity: ((E, E1)) => ListMap[ColumnName, Fragment] = {
+      val fromEntity: E0 => ListMap[ColumnName, Fragment] = (eta.revert _) andThen {
         case (e, e1) => repo1.fromEntity(e) ++ repo2.fromEntity(e1)
       }
-      val fromSelect: ((S, S1)) => ListMap[ColumnName, Fragment] = {
+      val fromSelect: S0 => ListMap[ColumnName, Fragment] = (sta.revert _) andThen {
         case (s, s1) => repo1.fromSelect(s) ++ repo2.fromSelect(s1)
       }
 
       def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = repo1.forNames { n =>
         repo2.forNames { n1 =>
-          f((n, n1))
+          f(nta.append(n, n1))
         }
       }
 
-      val joinOn: Option[Fragment] = on
+      val joinedOn: Option[Fragment] = on
         .map {
           case (nf, n1f) =>
             Fragment.const(repo1.forNames[Id](nf) + " = " + repo2.forNames[Id](n1f))

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
@@ -1,15 +1,17 @@
 package io.scalaland.ocdquery
 
-import cats.Id
+import cats.{ Functor, Id }
+import cats.syntax.functor._
 import doobie.Fragment
 import io.scalaland.ocdquery.internal._
 
 import scala.collection.immutable.{ ListMap, ListSet }
 
-trait RepoMeta[C, E, S] {
+sealed trait RepoMeta[C, E, S, N] {
   type Create = C
   type Entity = E
   type Select = S
+  type Names  = N
 
   val table:       Fragment
   val columnNames: ListSet[ColumnName]
@@ -18,7 +20,69 @@ trait RepoMeta[C, E, S] {
   val fromEntity: Entity => ListMap[ColumnName, Fragment]
   val fromSelect: Select => ListMap[ColumnName, Fragment]
 
+  def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName]
+
   lazy val * : Fragment = Fragment.const(columnNames.mkString(", "))
+}
+
+sealed trait UnnamedRepoMeta[C, E, S, N] extends RepoMeta[C, E, S, N] { repo =>
+
+  def as(name: String): NamedRepoMeta[C, E, S, N] =
+    new NamedRepoMeta[C, E, S, N] {
+
+      val table:       Fragment            = repo.table ++ Fragment.const(s" AS $name")
+      val columnNames: ListSet[ColumnName] = repo.columnNames.map(name + "." + _)
+
+      val fromCreate: Create => ListMap[ColumnName, Fragment] =
+        c => repo.fromCreate(c).map { case (k, v) => (name + "." + k) -> v }
+      val fromEntity: Entity => ListMap[ColumnName, Fragment] =
+        e => repo.fromEntity(e).map { case (k, v) => (name + "." + k) -> v }
+      val fromSelect: Select => ListMap[ColumnName, Fragment] =
+        s => repo.fromSelect(s).map { case (k, v) => (name + "." + k) -> v }
+
+      def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = repo.forNames(f).map("." + _)
+
+      val joinOn: Option[Fragment] = None
+    }
+}
+
+sealed trait NamedRepoMeta[C, E, S, N] extends RepoMeta[C, E, S, N] { repo1 =>
+
+  val joinOn: Option[Fragment]
+
+  def join[C1, E1, S1, N1](
+    repo2: NamedRepoMeta[C1, E1, S1, N1],
+    on:    (N => ColumnName, N1 => ColumnName)*
+  ): NamedRepoMeta[(C, C1), (E, E1), (S, S1), (N, N1)] =
+    new NamedRepoMeta[(C, C1), (E, E1), (S, S1), (N, N1)] {
+
+      // TODO: for now only join
+      val table:       Fragment            = repo1.table ++ Fragment.const(" JOIN ") ++ repo2.table
+      val columnNames: ListSet[ColumnName] = repo1.columnNames ++ repo1.columnNames
+
+      val fromCreate: ((C, C1)) => ListMap[ColumnName, Fragment] = {
+        case (c, c1) => repo1.fromCreate(c) ++ repo2.fromCreate(c1)
+      }
+      val fromEntity: ((E, E1)) => ListMap[ColumnName, Fragment] = {
+        case (e, e1) => repo1.fromEntity(e) ++ repo2.fromEntity(e1)
+      }
+      val fromSelect: ((S, S1)) => ListMap[ColumnName, Fragment] = {
+        case (s, s1) => repo1.fromSelect(s) ++ repo2.fromSelect(s1)
+      }
+
+      def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = repo1.forNames { n =>
+        repo2.forNames { n1 =>
+          f((n, n1))
+        }
+      }
+
+      val joinOn: Option[Fragment] = on
+        .map {
+          case (nf, n1f) =>
+            Fragment.const(repo1.forNames[Id](nf) + " = " + repo2.forNames[Id](n1f))
+        }
+        .reduceOption(_ ++ Fragment.const("AND") ++ _)
+    }
 }
 
 object RepoMeta {
@@ -31,8 +95,8 @@ object RepoMeta {
     forCreate:     FragmentsForCreate[Create, Columns],
     forEntity:     FragmentsForEntity[Entity, Columns],
     forSelect:     FragmentsForSelect[Select, Columns]
-  ): RepoMeta[Create, Entity, Select] =
-    new RepoMeta[Create, Entity, Select] {
+  ): UnnamedRepoMeta[Create, Entity, Select, Columns] =
+    new UnnamedRepoMeta[Create, Entity, Select, Columns] {
 
       val table:       Fragment            = Fragment.const(tableName)
       val columnNames: ListSet[ColumnName] = ListSet(cols.getList(columns).toSeq: _*)
@@ -43,6 +107,8 @@ object RepoMeta {
         ListMap(forEntity.toFragments(entity, columns).toSeq: _*)
       val fromSelect: Select => ListMap[ColumnName, Fragment] = select =>
         ListMap(forSelect.toFragments(select, columns).toSeq: _*)
+
+      def forNames[F[_]: Functor](f: Names => F[ColumnName]): F[ColumnName] = f(columns)
     }
 
   def forValue[ValueF[_[_]]](
@@ -53,7 +119,7 @@ object RepoMeta {
     forCreate:     FragmentsForCreate[ValueF[Id], ValueF[ColumnNameF]],
     forEntity:     FragmentsForEntity[ValueF[Id], ValueF[ColumnNameF]],
     forSelect:     FragmentsForSelect[ValueF[Selectable], ValueF[ColumnNameF]]
-  ): RepoMeta[ValueF[Id], ValueF[Id], ValueF[Selectable]] =
+  ): UnnamedRepoMeta[ValueF[Id], ValueF[Id], ValueF[Selectable], ValueF[ColumnNameF]] =
     instant[ValueF[Id], ValueF[Id], ValueF[Selectable], ValueF[ColumnNameF]](tableName, columns)
 
   def forEntity[EntityF[_[_], _[_]]](
@@ -64,7 +130,8 @@ object RepoMeta {
     forCreate:     FragmentsForCreate[EntityF[Id, UnitF], EntityF[ColumnNameF, ColumnNameF]],
     forEntity:     FragmentsForEntity[EntityF[Id, Id], EntityF[ColumnNameF, ColumnNameF]],
     forSelect:     FragmentsForSelect[EntityF[Selectable, Selectable], EntityF[ColumnNameF, ColumnNameF]]
-  ): RepoMeta[EntityF[Id, UnitF], EntityF[Id, Id], EntityF[Selectable, Selectable]] =
+  ): UnnamedRepoMeta[EntityF[Id, UnitF], EntityF[Id, Id], EntityF[Selectable, Selectable], EntityF[ColumnNameF,
+                                                                                                   ColumnNameF]] =
     instant[EntityF[Id, UnitF], EntityF[Id, Id], EntityF[Selectable, Selectable], EntityF[ColumnNameF, ColumnNameF]](
       tableName,
       columns

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/RepoMeta.scala
@@ -83,12 +83,18 @@ sealed trait NamedRepoMeta[C, E, S, N] extends RepoMeta[C, E, S, N] { meta0 =>
         }
       }
 
-      val joinedOn: Option[Fragment] = on
-        .map {
-          case (nf, n1f) =>
-            Fragment.const(meta0.forNames[Id](nf) + " = " + meta.forNames[Id](n1f))
+      val joinedOn: Option[Fragment] =
+        (meta0.joinedOn -> on
+          .map {
+            case (nf, n1f) =>
+              Fragment.const(meta0.forNames[Id](nf) + " = " + meta.forNames[Id](n1f))
+          }
+          .reduceOption(_ ++ Fragment.const("AND") ++ _)) match {
+          case (Some(j1), Some(j2)) => Some(j1 ++ Fragment.const("AND") ++ j2)
+          case (Some(j), None)      => Some(j)
+          case (None, Some(j))      => Some(j)
+          case (None, None)         => None
         }
-        .reduceOption(_ ++ Fragment.const("AND") ++ _)
     }
 }
 

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Selectable.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Selectable.scala
@@ -1,5 +1,7 @@
 package io.scalaland.ocdquery
 
+import io.scalaland.ocdquery.internal.Empty
+
 sealed trait Selectable[+A] extends Product with Serializable {
   def toOption: Option[A] = this match {
     case Fixed(a) => Some(a)
@@ -10,3 +12,8 @@ sealed trait Selectable[+A] extends Product with Serializable {
 final case class Fixed[+A](to: A) extends Selectable[A]
 
 case object Skipped extends Selectable[Nothing]
+
+object Selectable {
+
+  implicit def empty[A]: Empty[Selectable[A]] = () => Skipped
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/Sort.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/Sort.scala
@@ -1,0 +1,7 @@
+package io.scalaland.ocdquery
+
+sealed trait Sort extends Product with Serializable
+object Sort {
+  case object Ascending extends Sort
+  case object Descending extends Sort
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/Empty.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/Empty.scala
@@ -1,0 +1,22 @@
+package io.scalaland.ocdquery.internal
+
+import shapeless._
+
+trait Empty[A] {
+
+  lazy val value: A = get()
+
+  protected def get(): A
+}
+
+object Empty {
+
+  def apply[A](implicit empty: Empty[A]): Empty[A] = empty
+
+  implicit val hnilCase: Empty[HNil] = () => HNil
+
+  implicit def hconsCase[H, T <: HList](implicit h: Empty[H], t: Empty[T]): Empty[H :: T] = () => h.get() :: t.get()
+
+  implicit def productCase[P, Rep <: HList](implicit gen: Generic.Aux[P, Rep], empty: Empty[Rep]): Empty[P] =
+    () => gen.from(empty.get())
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/RandomName.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/RandomName.scala
@@ -1,0 +1,8 @@
+package io.scalaland.ocdquery.internal
+
+import scala.util.Random
+
+object RandomName {
+
+  def next: String = Random.alphanumeric.filter(_.isLetter).take(3).mkString.toLowerCase
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/SkipUnit.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/SkipUnit.scala
@@ -1,0 +1,44 @@
+package io.scalaland.ocdquery.internal
+
+import shapeless._
+
+trait SkipUnit[C] {
+
+  type SU
+
+  def from(skipped: SU): C
+}
+
+object SkipUnit extends SkipUnitLowLevelImplicit {
+
+  type Aux[C, SU0] = SkipUnit[C] { type SU = SU0 }
+
+  implicit val hnilCase: Aux[HNil, HNil] = new SkipUnit[HNil] {
+    type SU = HNil
+    def from(skipped: HNil): HNil = skipped
+  }
+
+  implicit def hconsUnitCase[T <: HList]: Aux[Unit :: T, T] = new SkipUnit[Unit :: T] {
+    type SU = T
+    def from(skipped: T): Unit :: T = () :: skipped
+  }
+
+  implicit def productCase[C, CRep <: HList, SURep <: HList](implicit
+                                                             cGen:     Generic.Aux[C, CRep],
+                                                             skip:     Aux[CRep, SURep],
+                                                             untupler: Untupler[SURep]): Aux[C, untupler.In] =
+    new SkipUnit[C] {
+      type SU = untupler.In
+      def from(skipped: untupler.In): C =
+        cGen.from(skip.from(untupler(skipped)))
+    }
+}
+
+trait SkipUnitLowLevelImplicit { self: SkipUnit.type =>
+
+  implicit def hconsNonUnitCase[H, SU0 <: HList, C <: HList](implicit skip: Aux[C, SU0]): Aux[H :: C, H :: SU0] =
+    new SkipUnit[H :: C] {
+      type SU = H :: SU0
+      def from(skipped: SU): H :: C = skipped.head :: skip.from(skipped.tail)
+    }
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/TupleAppender.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/TupleAppender.scala
@@ -12,6 +12,7 @@ object TupleAppender extends TupleAppenderLowPriorityImplicit {
 
   def apply[A, B, C](implicit ta: TupleAppender[A, B, C]): TupleAppender[A, B, C] = ta
 
+  //TODO: rewrite using Untupler
   implicit def appendTuple[A, ARep <: HList, ASize <: Nat, B, C <: Product, CGen <: HList](
     implicit aIsTuple: IsTuple[A],
     aGen:              Generic.Aux[A, ARep],

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/TupleAppender.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/TupleAppender.scala
@@ -1,0 +1,47 @@
+package io.scalaland.ocdquery.internal
+
+import shapeless._
+import shapeless.ops.hlist.{ Length, Prepend, Split }
+
+trait TupleAppender[A, B, C] {
+  def append(a: A, b: B): C
+  def revert(c: C): (A, B)
+}
+
+object TupleAppender extends TupleAppenderLowPriorityImplicit {
+
+  def apply[A, B, C](implicit ta: TupleAppender[A, B, C]): TupleAppender[A, B, C] = ta
+
+  implicit def appendTuple[A, ARep <: HList, ASize <: Nat, B, C <: Product, CGen <: HList](
+    implicit aIsTuple: IsTuple[A],
+    aGen:              Generic.Aux[A, ARep],
+    aSize:             Length.Aux[ARep, ASize],
+    prepend:           Prepend.Aux[ARep, B :: HNil, CGen],
+    split:             Split.Aux[CGen, ASize, ARep, B :: HNil],
+    cIsTuple:          IsTuple[C],
+    cGen:              Generic.Aux[C, CGen]
+  ): TupleAppender[A, B, C] = new TupleAppender[A, B, C] {
+
+    aIsTuple.hashCode()
+    aSize.hashCode()
+    cIsTuple.hashCode()
+
+    def append(a: A, b: B): C =
+      cGen.from(prepend(aGen.to(a), b :: HNil))
+
+    def revert(c: C): (A, B) = {
+      val (aRep, b :: HNil) = split(cGen.to(c))
+      aGen.from(aRep) -> b
+    }
+  }
+}
+
+trait TupleAppenderLowPriorityImplicit {
+
+  implicit def appendNonTuple[A, B]: TupleAppender[A, B, (A, B)] = new TupleAppender[A, B, (A, B)] {
+
+    def append(a: A, b: B): (A, B) = (a, b)
+
+    def revert(c: (A, B)): (A, B) = c
+  }
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/internal/Untupler.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/internal/Untupler.scala
@@ -1,0 +1,153 @@
+package io.scalaland.ocdquery.internal
+
+import shapeless._
+
+trait Untupler[L <: HList] {
+  type In
+  def apply(in: In): L
+}
+
+object Untupler {
+  type Aux[L <: HList, In0] = Untupler[L] { type In = In0 }
+
+  private def instance[L <: HList, In0](f: In0 => L): Aux[L, In0] = new Untupler[L] {
+    type In = In0
+    def apply(in: In0): L = f(in)
+  }
+
+  // scalastyle:off
+  implicit val untupler0:       Aux[HNil, Unit]             = instance { case ()     => HNil }
+  implicit def untupler1[A]:    Aux[A :: HNil, A]           = instance { case a      => a :: HNil }
+  implicit def untupler2[A, B]: Aux[A :: B :: HNil, (A, B)] = instance { case (a, b) => a :: b :: HNil }
+  implicit def untupler3[A, B, C]: Aux[A :: B :: C :: HNil, (A, B, C)] = instance {
+    case (a, b, c) => a :: b :: c :: HNil
+  }
+  implicit def untupler4[A, B, C, D]: Aux[A :: B :: C :: D :: HNil, (A, B, C, D)] =
+    instance { case (a, b, c, d) => a :: b :: c :: d :: HNil }
+
+  implicit def untupler5[A, B, C, D, E]: Aux[A :: B :: C :: D :: E :: HNil, (A, B, C, D, E)] =
+    instance { case (a, b, c, d, e) => a :: b :: c :: d :: e :: HNil }
+
+  implicit def untupler6[A, B, C, D, E, F]: Aux[A :: B :: C :: D :: E :: F :: HNil, (A, B, C, D, E, F)] =
+    instance { case (a, b, c, d, e, f) => a :: b :: c :: d :: e :: f :: HNil }
+
+  implicit def untupler7[A, B, C, D, E, F, G]: Aux[A :: B :: C :: D :: E :: F :: G :: HNil, (A, B, C, D, E, F, G)] =
+    instance { case (a, b, c, d, e, f, g) => a :: b :: c :: d :: e :: f :: g :: HNil }
+
+  implicit def untupler8[A, B, C, D, E, F, G, H]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: HNil,
+                                                      (A, B, C, D, E, F, G, H)] =
+    instance { case (a, b, c, d, e, f, g, h) => a :: b :: c :: d :: e :: f :: g :: h :: HNil }
+
+  implicit def untupler9[A, B, C, D, E, F, G, H, I]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: HNil,
+                                                         (A, B, C, D, E, F, G, H, I)] =
+    instance { case (a, b, c, d, e, f, g, h, i) => a :: b :: c :: d :: e :: f :: g :: h :: i :: HNil }
+
+  implicit def untupler10[A, B, C, D, E, F, G, H, I, J]: Aux[A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: HNil,
+                                                             (A, B, C, D, E, F, G, H, I, J)] =
+    instance { case (a, b, c, d, e, f, g, h, i, j) => a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: HNil }
+
+  implicit def untupler11[A, B, C, D, E, F, G, H, I, J, K]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K)
+  ] =
+    instance { case (a, b, c, d, e, f, g, h, i, j, k) => a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: HNil }
+
+  implicit def untupler12[A, B, C, D, E, F, G, H, I, J, K, L]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l) => a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: HNil
+    }
+
+  implicit def untupler13[A, B, C, D, E, F, G, H, I, J, K, L, M]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: HNil
+    }
+
+  implicit def untupler14[A, B, C, D, E, F, G, H, I, J, K, L, M, N]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: HNil
+    }
+
+  implicit def untupler15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: HNil
+    }
+
+  implicit def untupler16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: HNil
+    }
+
+  implicit def untupler17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: HNil
+    }
+
+  implicit def untupler18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: HNil
+    }
+
+  implicit def untupler19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: HNil
+    }
+
+  implicit def untupler20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: HNil
+    }
+
+  implicit def untupler21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: u :: HNil
+    }
+
+  implicit def untupler22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]: Aux[
+    A :: B :: C :: D :: E :: F :: G :: H :: I :: J :: K :: L :: M :: N :: O :: P :: Q :: R :: S :: T :: U :: V :: HNil,
+    (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+  ] =
+    instance {
+      case (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) =>
+        a :: b :: c :: d :: e :: f :: g :: h :: i :: j :: k :: l :: m :: n :: o :: p :: q :: r :: s :: t :: u :: v :: HNil
+    }
+  // scalastyle:on
+}

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/package.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/package.scala
@@ -18,14 +18,14 @@ package object ocdquery {
   implicit class FragmentsOps(val fragments: ListMap[ColumnName, Fragment]) extends AnyVal {
 
     def asSelect: Fragment =
-      fragments.keysIterator.map(Fragment.const(_)).reduce(_ ++ fr" , " ++ _)
+      fragments.keysIterator.map(Fragment.const(_)).reduce(_ ++ fr"," ++ _)
     def asAnd: Fragment =
-      fragments.map { case (column, value) => Fragment.const(s"$column = ") ++ value }.reduce(_ ++ fr" AND " ++ _)
+      fragments.map { case (column, value) => Fragment.const(s"$column = ") ++ value }.reduce(_ ++ fr"AND" ++ _)
     def asOr: Fragment =
-      fragments.map { case (column, value) => Fragment.const(s"$column = ") ++ value }.reduce(_ ++ fr" OR " ++ _)
+      fragments.map { case (column, value) => Fragment.const(s"$column = ") ++ value }.reduce(_ ++ fr"OR" ++ _)
     def asSet: Fragment =
-      fragments.map { case (column, value) => Fragment.const(s"$column =") ++ value }.reduce(_ ++ fr", " ++ _)
+      fragments.map { case (column, value) => Fragment.const(s"$column =") ++ value }.reduce(_ ++ fr"," ++ _)
     def asValues: Fragment =
-      fragments.valuesIterator.reduce(_ ++ fr", " ++ _)
+      fragments.valuesIterator.reduce(_ ++ fr"," ++ _)
   }
 }

--- a/modules/core/src/main/scala/io/scalaland/ocdquery/package.scala
+++ b/modules/core/src/main/scala/io/scalaland/ocdquery/package.scala
@@ -28,4 +28,6 @@ package object ocdquery {
     def asValues: Fragment =
       fragments.valuesIterator.reduce(_ ++ fr"," ++ _)
   }
+
+  implicit def liftToSelectable[A](a: A): Selectable[A] = Option(a).map(Fixed(_)).getOrElse(Skipped)
 }

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -4,10 +4,10 @@ import java.time.LocalDate
 
 import cats.Id
 import cats.implicits._
+import com.softwaremill.quicklens._
 import doobie._
 import doobie.implicits._
 import io.scalaland.ocdquery.example.{ TicketF, TicketRepo }
-import monocle.macros.syntax.lens._
 import org.specs2.mutable.Specification
 
 class FetcherSpec extends Specification with WithH2Database {
@@ -51,7 +51,11 @@ class FetcherSpec extends Specification with WithH2Database {
         _ = inserted === 1
 
         // should fetch duplicated entity
-        byName = TicketRepo.emptySelect.lens(_.name).set(createTicket.name).lens(_.surname).set(createTicket.surname)
+        byName = TicketRepo.emptySelect
+          .modify(_.name)
+          .setTo(createTicket.name)
+          .modify(_.surname)
+          .setTo(createTicket.surname)
 
         result1 <- join1.fetch((byName, byName)).to[List]
         result2 <- join2.fetch((byName, byName, byName)).to[List]

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -50,13 +50,9 @@ class FetcherSpec extends Specification with WithH2Database {
         _ = inserted === 1
 
         // should fetch duplicated entity
-        byName = TicketF[Selectable, Selectable](
-          id      = Skipped,
-          name    = Fixed(createTicket.name),
-          surname = Fixed(createTicket.surname),
-          from    = Skipped,
-          to      = Skipped,
-          date    = Skipped
+        byName = TicketRepo.emptySelect.copy[Selectable, Selectable](
+          name    = createTicket.name,
+          surname = createTicket.surname
         )
         result1 <- join1.fetch((byName, byName)).to[List]
         result2 <- join2.fetch((byName, byName, byName)).to[List]

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import doobie._
 import doobie.implicits._
 import io.scalaland.ocdquery.example.{ TicketF, TicketRepo }
+import monocle.macros.syntax.lens._
 import org.specs2.mutable.Specification
 
 class FetcherSpec extends Specification with WithH2Database {
@@ -50,10 +51,8 @@ class FetcherSpec extends Specification with WithH2Database {
         _ = inserted === 1
 
         // should fetch duplicated entity
-        byName = TicketRepo.emptySelect.copy[Selectable, Selectable](
-          name    = createTicket.name,
-          surname = createTicket.surname
-        )
+        byName = TicketRepo.emptySelect.lens(_.name).set(createTicket.name).lens(_.surname).set(createTicket.surname)
+
         result1 <- join1.fetch((byName, byName)).to[List]
         result2 <- join2.fetch((byName, byName, byName)).to[List]
       } yield result1 -> result2

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -1,0 +1,68 @@
+package io.scalaland.ocdquery
+
+import java.time.LocalDate
+
+import cats.Id
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import io.scalaland.ocdquery.example.{ TicketF, TicketRepo }
+import org.specs2.mutable.Specification
+
+class FetcherSpec extends Specification with WithH2Database {
+
+  override def beforeAll(): Unit = {
+    sql"""CREATE TABLE IF NOT EXISTS tickets (
+            id       UUID DEFAULT random_uuid() PRIMARY KEY,
+            name     TEXT NOT NULL,
+            surname  TEXT NOT NULL,
+            from_    TEXT NOT NULL,
+            to       TEXT NOT NULL,
+            date     DATE NOT NULL
+          )""".update.run.transact(transactor).unsafeRunSync
+    ()
+  }
+
+  "Fetcher" should {
+
+    "generate Fragments allowing you to perform basic CRUD operations" in {
+      val createTicket = TicketF[Id, UnitF](
+        id      = (),
+        name    = "John",
+        surname = "Smith",
+        from    = "New York",
+        to      = "London",
+        date    = LocalDate.now()
+      )
+
+      import TicketRepo.meta.{ Create, Entity, Names, Select }
+      type Double[A] = (A, A)
+      type Triple[A] = (A, A, A)
+
+      val join1: Fetcher[Double[Create], Double[Entity], Double[Select], Double[Names]] =
+        TicketRepo.join(TicketRepo, (TicketRepo.col(_.name), TicketRepo.col(_.name)))
+      val join2: Fetcher[Triple[Create], Triple[Entity], Triple[Select], Triple[Names]] =
+        join1.join(TicketRepo, (_._2.name, TicketRepo.col(_.name)))
+
+      val test: ConnectionIO[(List[Double[Entity]], List[Triple[Entity]])] = for {
+        // should generate ID within SQL
+        inserted <- TicketRepo.insert(createTicket).run
+        _ = inserted === 1
+
+        // should fetch duplicated entity
+        byName = TicketF[Selectable, Selectable](
+          id      = Skipped,
+          name    = Fixed(createTicket.name),
+          surname = Fixed(createTicket.surname),
+          from    = Skipped,
+          to      = Skipped,
+          date    = Skipped
+        )
+        result1 <- join1.fetch((byName, byName)).to[List]
+        result2 <- join2.fetch((byName, byName, byName)).to[List]
+      } yield result1 -> result2
+
+      test.transact(transactor).unsafeRunSync() === None
+    }
+  }
+}

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -62,7 +62,20 @@ class FetcherSpec extends Specification with WithH2Database {
         result2 <- join2.fetch((byName, byName, byName)).to[List]
       } yield result1 -> result2
 
-      test.transact(transactor).unsafeRunSync() === None
+      val (result1: List[Double[Entity]], result2: List[Triple[Entity]]) = test.transact(transactor).unsafeRunSync()
+
+      result1.foreach {
+        case (e1, e2) =>
+          e1 === e2
+      }
+      result1 must not(empty)
+
+      result2.foreach {
+        case (e1, e2, e3) =>
+          e1 === e2
+          e2 === e3
+      }
+      result2 must not(empty)
     }
   }
 }

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -2,7 +2,6 @@ package io.scalaland.ocdquery
 
 import java.time.LocalDate
 
-import cats.Id
 import cats.implicits._
 import com.softwaremill.quicklens._
 import doobie._
@@ -27,14 +26,7 @@ class FetcherSpec extends Specification with WithH2Database {
   "Fetcher" should {
 
     "generate Fragments allowing you to perform basic CRUD operations" in {
-      val createTicket = TicketF[Id, UnitF](
-        id      = (),
-        name    = "John",
-        surname = "Smith",
-        from    = "New York",
-        to      = "London",
-        date    = LocalDate.now()
-      )
+      val createTicket = Create.entity[TicketF].fromTuple(("John", "Smith", "New York", "London", LocalDate.now()))
 
       import TicketRepo.meta.{ Create, Entity, Names, Select }
       type Double[A] = (A, A)

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/FetcherSpec.scala
@@ -25,17 +25,17 @@ class FetcherSpec extends Specification with WithH2Database {
 
   "Fetcher" should {
 
+    import TicketRepo.meta.{ Create, Entity, Names, Select }
+    type Double[A] = (A, A)
+    type Triple[A] = (A, A, A)
+
+    val join1: Fetcher[Double[Create], Double[Entity], Double[Select], Double[Names]] =
+      TicketRepo.join(TicketRepo, (TicketRepo.col(_.id), TicketRepo.col(_.id)))
+    val join2: Fetcher[Triple[Create], Triple[Entity], Triple[Select], Triple[Names]] =
+      join1.join(TicketRepo, (_._2.id, TicketRepo.col(_.id)))
+
     "generate Fragments allowing you to perform basic CRUD operations" in {
       val createTicket = Create.entity[TicketF].fromTuple(("John", "Smith", "New York", "London", LocalDate.now()))
-
-      import TicketRepo.meta.{ Create, Entity, Names, Select }
-      type Double[A] = (A, A)
-      type Triple[A] = (A, A, A)
-
-      val join1: Fetcher[Double[Create], Double[Entity], Double[Select], Double[Names]] =
-        TicketRepo.join(TicketRepo, (TicketRepo.col(_.name), TicketRepo.col(_.name)))
-      val join2: Fetcher[Triple[Create], Triple[Entity], Triple[Select], Triple[Names]] =
-        join1.join(TicketRepo, (_._2.name, TicketRepo.col(_.name)))
 
       val test: ConnectionIO[(List[Double[Entity]], List[Triple[Entity]])] = for {
         // should generate ID within SQL
@@ -67,6 +67,50 @@ class FetcherSpec extends Specification with WithH2Database {
           e2 === e3
       }
       result2 must not(empty)
+    }
+
+    "generate valid pagination" in {
+      val now = LocalDate.now()
+
+      val names = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
+
+      val toCreate = names.map { name =>
+        Create.entity[TicketF].fromTuple((name, "TestFetcher", "TestFetcher", "TestFetcher", now))
+      }
+
+      val filter =
+        TicketRepo.emptySelect
+          .modify(_.surname)
+          .setTo("TestFetcher")
+          .modify(_.from)
+          .setTo("TestFetcher")
+          .modify(_.to)
+          .setTo("TestFetcher")
+
+      val test = for {
+        inserted <- toCreate.traverse(TicketRepo.insert(_).run).map(_.sum)
+        _ = inserted === toCreate.length
+
+        all1 <- join1.fetch((filter, filter)).to[List]
+        _ = all1.map(_._1.name).toSet === names.toSet
+        _ = all1.map(_._2.name).toSet === names.toSet
+        all2 <- join2.fetch((filter, filter, filter)).to[List]
+        _ = all2.map(_._1.name).toSet === names.toSet
+        _ = all2.map(_._2.name).toSet === names.toSet
+        _ = all2.map(_._3.name).toSet === names.toSet
+
+        firstHalf <- join2
+          .fetch((filter, filter, filter), Some(((_: Triple[Names])._1.name) -> Sort.Ascending), None, Some(5))
+          .to[List]
+        _ = firstHalf.map(_._1.name) === names.take(5)
+        _ = firstHalf.map(_._2.name) === names.take(5)
+        _ = firstHalf.map(_._3.name) === names.take(5)
+        secondHalf <- join2
+          .fetch((filter, filter, filter), Some(((_: Triple[Names])._1.name) -> Sort.Ascending), Some(5), None)
+          .to[List]
+      } yield secondHalf.map(_._1.name)
+
+      test.transact(transactor).unsafeRunSync() === names.drop(5)
     }
   }
 }

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
@@ -129,9 +129,13 @@ final class RepoSpec extends Specification with WithH2Database {
         _ = inserted === toCreate.length
         all <- TicketRepo.fetch(filter).to[List]
         _ = all.map(_.name).toSet === names.toSet
-        firstHalf <- TicketRepo.fetch(filter, Some("name" -> Repo.Sort.Ascending), None, Some(5)).to[List]
+        firstHalf <- TicketRepo
+          .fetch(filter, Some(TicketRepo.col(_.name) -> Repo.Sort.Ascending), None, Some(5))
+          .to[List]
         _ = firstHalf.map(_.name) === names.take(5)
-        secondHalf <- TicketRepo.fetch(filter, Some("name" -> Repo.Sort.Ascending), Some(5), None).to[List]
+        secondHalf <- TicketRepo
+          .fetch(filter, Some(TicketRepo.col(_.name) -> Repo.Sort.Ascending), Some(5), None)
+          .to[List]
       } yield secondHalf.map(_.name)
 
       test.transact(transactor).unsafeRunSync() === names.drop(5)

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
@@ -41,13 +41,9 @@ final class RepoSpec extends Specification with WithH2Database {
         _ = inserted === 1
 
         // should fetch complete entity
-        byName = TicketF[Selectable, Selectable](
-          id      = Skipped,
-          name    = Fixed(createTicket.name),
-          surname = Fixed(createTicket.surname),
-          from    = Skipped,
-          to      = Skipped,
-          date    = Skipped
+        byName = TicketRepo.emptySelect.copy[Selectable, Selectable](
+          name    = createTicket.name,
+          surname = createTicket.surname
         )
         fetchedTicket <- TicketRepo.fetch(byName, limitOpt = Some(1)).unique
         expectedTicket = TicketF[Id, Id](
@@ -61,13 +57,8 @@ final class RepoSpec extends Specification with WithH2Database {
         _ = fetchedTicket === expectedTicket
 
         // should update all fields but id
-        byId = TicketF[Selectable, Selectable](
-          id      = Fixed(fetchedTicket.id),
-          name    = Skipped,
-          surname = Skipped,
-          from    = Skipped,
-          to      = Skipped,
-          date    = Skipped
+        byId = TicketRepo.emptySelect.copy[Selectable, Selectable](
+          id = fetchedTicket.id
         )
         expectedUpdated = TicketF[Id, Id](
           id      = fetchedTicket.id,
@@ -77,13 +68,12 @@ final class RepoSpec extends Specification with WithH2Database {
           to      = "New York",
           date    = LocalDate.now().plusDays(5) // scalastyle:ignore
         )
-        update = TicketF[Selectable, Selectable](
-          id      = Skipped,
-          name    = Fixed(expectedUpdated.name),
-          surname = Fixed(expectedUpdated.surname),
-          from    = Fixed(expectedUpdated.from),
-          to      = Fixed(expectedUpdated.to),
-          date    = Fixed(expectedUpdated.date)
+        update = TicketRepo.emptySelect.copy[Selectable, Selectable](
+          name    = expectedUpdated.name,
+          surname = expectedUpdated.surname,
+          from    = expectedUpdated.from,
+          to      = expectedUpdated.to,
+          date    = expectedUpdated.date
         )
         updated <- TicketRepo.update(byId, update).run
         _ = updated === 1
@@ -115,13 +105,10 @@ final class RepoSpec extends Specification with WithH2Database {
         )
       }
 
-      val filter = TicketF[Selectable, Selectable](
-        id      = Skipped,
-        name    = Skipped,
-        surname = Fixed("Test"),
-        from    = Fixed("Test"),
-        to      = Fixed("Test"),
-        date    = Skipped
+      val filter = TicketRepo.emptySelect.copy[Selectable, Selectable](
+        surname = "Test",
+        from    = "Test",
+        to      = "Test"
       )
 
       val test = for {

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
@@ -27,14 +27,17 @@ final class RepoSpec extends Specification with WithH2Database {
   "Repo" should {
 
     "generate Fragments allowing you to perform basic CRUD operations" in {
-      val createTicket = TicketF[Id, UnitF](
-        id      = (),
-        name    = "John",
-        surname = "Smith",
-        from    = "New York",
-        to      = "London",
-        date    = LocalDate.now()
-      )
+      val createTicket = Create
+        .entity[TicketF]
+        .fromTuple(
+          (
+            "John",
+            "Smith",
+            "New York",
+            "London",
+            LocalDate.now()
+          )
+        )
 
       val test: ConnectionIO[Option[TicketF[Id, Id]]] = for {
         // should generate ID within SQL
@@ -99,14 +102,7 @@ final class RepoSpec extends Specification with WithH2Database {
       val names = List("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k")
 
       val toCreate = names.map { name =>
-        TicketF[Id, UnitF](
-          id      = (),
-          name    = name,
-          surname = "Test",
-          from    = "Test",
-          to      = "Test",
-          date    = now
-        )
+        Create.entity[TicketF].fromTuple((name, "Test", "Test", "Test", now))
       }
 
       val filter =

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/RepoSpec.scala
@@ -113,13 +113,9 @@ final class RepoSpec extends Specification with WithH2Database {
         _ = inserted === toCreate.length
         all <- TicketRepo.fetch(filter).to[List]
         _ = all.map(_.name).toSet === names.toSet
-        firstHalf <- TicketRepo
-          .fetch(filter, Some(TicketRepo.col(_.name) -> Repo.Sort.Ascending), None, Some(5))
-          .to[List]
+        firstHalf <- TicketRepo.fetch(filter, Some(TicketRepo.col(_.name) -> Sort.Ascending), None, Some(5)).to[List]
         _ = firstHalf.map(_.name) === names.take(5)
-        secondHalf <- TicketRepo
-          .fetch(filter, Some(TicketRepo.col(_.name) -> Repo.Sort.Ascending), Some(5), None)
-          .to[List]
+        secondHalf <- TicketRepo.fetch(filter, Some(TicketRepo.col(_.name) -> Sort.Ascending), Some(5), None).to[List]
       } yield secondHalf.map(_.name)
 
       test.transact(transactor).unsafeRunSync() === names.drop(5)

--- a/modules/core/src/test/scala/io/scalaland/ocdquery/example/TicketRepo.scala
+++ b/modules/core/src/test/scala/io/scalaland/ocdquery/example/TicketRepo.scala
@@ -1,17 +1,8 @@
 package io.scalaland.ocdquery.example
 
+import com.softwaremill.quicklens._
 import doobie.h2.implicits._
 import io.scalaland.ocdquery._
 
 object TicketRepo
-    extends Repo(
-      RepoMeta.forEntity("tickets",
-                         TicketF[ColumnNameF, ColumnNameF](
-                           id      = "id",
-                           name    = "name",
-                           surname = "surname",
-                           from    = "from_",
-                           to      = "to",
-                           date    = "date"
-                         ))
-    )
+    extends Repo(RepoMeta.forEntity("tickets", DefaultColumnNames.forEntity[TicketF].modify(_.from).setTo("from_")))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
 
   // libraries versions
   val doobieVersion   = "0.7.0"
+  val monocleVersion  = "1.6.0"
   val specs2Version   = "4.5.1"
 
   // resolvers
@@ -26,6 +27,8 @@ object Dependencies {
   val doobieH2           = "org.tpolecat"                 %% "doobie-h2"                 % doobieVersion
   val doobieSpecs2       = "org.tpolecat"                 %% "doobie-specs2"             % doobieVersion
   val shapeless          = "com.chuusai"                  %% "shapeless"                 % "2.3.3"
+  val monocle            = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
+  val monocleMacros      = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
   // testing
   val spec2Core          = "org.specs2"                   %% "specs2-core"               % specs2Version
   val spec2Mock          = "org.specs2"                   %% "specs2-mock"               % specs2Version
@@ -44,7 +47,7 @@ trait Dependencies {
 
   val mainDeps = Seq(doobie, shapeless)
 
-  val testDeps = Seq(doobieH2, doobieSpecs2, spec2Core, spec2Mock, spec2Scalacheck)
+  val testDeps = Seq(doobieH2, doobieSpecs2, spec2Core, spec2Mock, spec2Scalacheck, monocle, monocleMacros)
 
   implicit final class ProjectRoot(project: Project) {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,6 @@ object Dependencies {
 
   // libraries versions
   val doobieVersion   = "0.7.0"
-  val monocleVersion  = "1.6.0"
   val specs2Version   = "4.5.1"
 
   // resolvers
@@ -27,8 +26,7 @@ object Dependencies {
   val doobieH2           = "org.tpolecat"                 %% "doobie-h2"                 % doobieVersion
   val doobieSpecs2       = "org.tpolecat"                 %% "doobie-specs2"             % doobieVersion
   val shapeless          = "com.chuusai"                  %% "shapeless"                 % "2.3.3"
-  val monocle            = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
-  val monocleMacros      = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
+  val quicklens          = "com.softwaremill.quicklens"   %% "quicklens"                 % "1.4.12"
   // testing
   val spec2Core          = "org.specs2"                   %% "specs2-core"               % specs2Version
   val spec2Mock          = "org.specs2"                   %% "specs2-mock"               % specs2Version
@@ -47,7 +45,7 @@ trait Dependencies {
 
   val mainDeps = Seq(doobie, shapeless)
 
-  val testDeps = Seq(doobieH2, doobieSpecs2, spec2Core, spec2Mock, spec2Scalacheck, monocle, monocleMacros)
+  val testDeps = Seq(doobieH2, doobieSpecs2, spec2Core, spec2Mock, spec2Scalacheck, quicklens)
 
   implicit final class ProjectRoot(project: Project) {
 


### PR DESCRIPTION
A bit more work that initially planed landed here:
* added `Fetcher` which allows for joins between `Repo`s to fetch tuples of entities/values
* utility for creating entities without passing `Unit` for empty fields and with no need to declare type parameters in case class (see `Create` object)
* utility for default column names handling